### PR TITLE
Fix CI bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    name: "Build the app"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,7 +21,7 @@ jobs:
           version: latest
       
       - name: Install dependencies
-        run: pnpm install
+          run: pnpm install
   
       - name: Build project
-        run: pnpm build
+          run: pnpm build


### PR DESCRIPTION
"Build the app" job is not appearing in Github settings because there is no name of the job. This pull request should fix it.