### PR TITLE
Fix deployment bug

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,6 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()]
+  plugins: [vue()],
+  base: "/SimpleTimer/"
 })


### PR DESCRIPTION
Empty page was served by the production server. It was caused by incorrect js and assests path, because the app was not located at the root path, but at the `/SimpleTimer/`. Adding the base path to vite.config.ts can fix it.